### PR TITLE
Attempt fix: Change absolute file path to relative in CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -180,7 +180,7 @@ body {
 .life-icon {
   width: 60px;
   height: 42px;
-  background-image: url('/assets/media/grougu_lives_2_55x40.png');
+  background-image: url('../media/grougu_lives_2_55x40.png');
   background-size: cover;
   margin-right: 10px;
 }


### PR DESCRIPTION
Attempting to fix why grogu life containers do not render on deployed version. I suspect it's my awful habit of writing dodgy absolute file paths. Let's see if this works.